### PR TITLE
Fix bad type for Site.Count* properties Was string instead of integers

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -15735,27 +15735,27 @@
         },
         "count_prefixes": {
           "title": "Count prefixes",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "count_vlans": {
           "title": "Count vlans",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "count_racks": {
           "title": "Count racks",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "count_devices": {
           "title": "Count devices",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         },
         "count_circuits": {
           "title": "Count circuits",
-          "type": "string",
+          "type": "integer",
           "readOnly": true
         }
       }


### PR DESCRIPTION
Here is an example of what the netbox API currently returns :

```
  Server:           nginx/1.10.3
  Date:             Tue, 06 Nov 2018 16:05:40 GMT
  Content-Type:     application/json
  Content-Length:   545
  Connection:       keep-alive
  Allow:            GET, POST, HEAD, OPTIONS
  X-Frame-Options:  SAMEORIGIN
  API-Version:      2.4
  Vary:             Accept, Cookie, Origin
  JSON
  [m:Auto]
  {
      "count": 1,
      "next": null,
      "previous": null,
      "results": [
          {
              "asn": null,
              "comments": "",
              "contact_email": "",
              "contact_name": "",
              "contact_phone": "",
              "count_circuits": 0,
              "count_devices": 0,
              "count_prefixes": 0,
              "count_racks": 0,
              "count_vlans": 0,
              "created": "2018-11-05",
              "custom_fields": {},
              "description": "",
              "facility": "",
              "id": 2,
              "last_updated": "2018-11-05T15:07:34.468311Z",
              "latitude": null,
              "longitude": null,
              "name": "test",
              "physical_address": "",
              "region": null,
              "shipping_address": "",
              "slug": "test",
              "status": {
                  "label": "Active",
                  "value": 1
              },
              "tags": [],
              "tenant": null,
              "time_zone": null
          }
      ]
  }
```

I'm not sure about the camelcase to underscored files naming but it works anyway