### PR TITLE
Make enforce_unique flag for VRF a pointer

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -39848,7 +39848,8 @@
         "enforce_unique": {
           "title": "Enforce unique space",
           "description": "Prevent duplicate prefixes/IP addresses within this VRF",
-          "type": "boolean"
+          "type": "boolean",
+          "x-nullable": true
         },
         "description": {
           "title": "Description",
@@ -39928,7 +39929,8 @@
         "enforce_unique": {
           "title": "Enforce unique space",
           "description": "Prevent duplicate prefixes/IP addresses within this VRF",
-          "type": "boolean"
+          "type": "boolean",
+          "x-nullable": true
         },
         "description": {
           "title": "Description",


### PR DESCRIPTION
setting enforce_unique=false while creating VRF seems to have no effect.
enforce_unique is always set to true.
Making this property a boolean pointer should fix the issue.

Issue: GH-86