### PR TITLE
Update Go to 1.18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.15.x", "1.17.x"]
+        go: ["1.17.x", "1.18.x"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.gobincache/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 deps:
 	go mod download
-	GO111MODULE=off go get -u github.com/myitcv/gobin
+	go install github.com/go-swagger/go-swagger/cmd/swagger@latest
 
 generate: deps
-	gobin -m -run github.com/go-swagger/go-swagger/cmd/swagger generate client --copyright-file=copyright_header.txt
+	swagger generate client --target=./netbox --copyright-file=copyright_header.txt
 
 clean:
 	rm -rf netbox/client netbox/models

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netbox-community/go-netbox
 
-go 1.16
+go 1.18
 
 require (
 	github.com/go-openapi/errors v0.20.1


### PR DESCRIPTION
This PR updates the library to use the latest Go release, since it is backwards compatible and 1.16 reached its EOL on February 2021.

In addition, it improves the Makefile by using Go's most recent features.