### PR TITLE
Automatically create releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,13 @@ jobs:
         go: ["1.17.x", "1.18.x"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
 
       - name: License check
         run: ./scripts/licensecheck.sh
 
       - name: Go installation
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "netbox_*"
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
This PR adds a GitHub workflow that automatically creates a new release (with autogenerated release notes) when a new tag is created.

In addition, it pins versions of actions used in the main workflow, since it is a good practice that ensures reproducibility.