### PR TITLE
Fixes #205: Removes tagged_items from required properties for Tags.

### DIFF
--- a/model_tag.go
+++ b/model_tag.go
@@ -475,7 +475,6 @@ func (o *Tag) UnmarshalJSON(data []byte) (err error) {
 		"display",
 		"name",
 		"slug",
-		"tagged_items",
 	}
 
 	// defaultValueFuncMap captures the default values for required properties.

--- a/scripts/fix-spec.py
+++ b/scripts/fix-spec.py
@@ -87,6 +87,7 @@ if 'components' in data and 'schemas' in data['components']:
             'allocated_vcpus', # issue #199
             'allocated_memory', # issue #199
             'allocated_disk', # issue #199
+            'tagged_items', # issue #205
         ] + dynamic_non_required_props
 
         if 'required' in schema:


### PR DESCRIPTION
Removes tagged_items from both model_tag.go and the fix-spec script.