### PR TITLE
Fix Device.UnmarshalJSON rejecting empty description string

### DIFF
--- a/model_device.go
+++ b/model_device.go
@@ -1962,13 +1962,13 @@ func (o *Device) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	for _, requiredProperty := range requiredProperties {
-		if value, exists := allProperties[requiredProperty]; !exists || value == "" {
+		if _, exists := allProperties[requiredProperty]; !exists {
 			if _, ok := defaultValueFuncMap[requiredProperty]; ok {
 				allProperties[requiredProperty] = defaultValueFuncMap[requiredProperty]()
 				defaultValueApplied = true
 			}
 		}
-		if value, exists := allProperties[requiredProperty]; !exists || value == "" {
+		if _, exists := allProperties[requiredProperty]; !exists {
 			return fmt.Errorf("no value given for required property %v", requiredProperty)
 		}
 	}


### PR DESCRIPTION
## Problem 
NetBox 4.4.7 webhooks send device data with `description` as an empty string `""` instead of `null` when the field is empty.
The current validation logic in `UnmarshalJSON` incorrectly rejects empty strings as invalid values for required string fields.
This causes unmarshaling to fail with the error: no value given for required property description

## Solution
Removed the `|| value == ""` check from the `UnmarshalJSON` validation logic in `model_device.go`. 
An empty string is a valid value for a string field - the validation should only check that the property exists in the JSON payload, not whether it's an empty string.

## Testing
Tested with NetBox 4.4.7 payloads containing `"description": ""` - unmarshaling now succeeds.

## Notes
This same pattern (`|| value == ""`) exists in approximately 1200 other places across the model files. This PR fixes the specific issue I encountered with the Device model.